### PR TITLE
Add Avalonia GUI for exploring Neobem source structure

### DIFF
--- a/gui/App.axaml
+++ b/gui/App.axaml
@@ -1,0 +1,8 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="gui.App"
+             RequestedThemeVariant="Default">
+  <Application.Styles>
+    <FluentTheme />
+  </Application.Styles>
+</Application>

--- a/gui/App.axaml.cs
+++ b/gui/App.axaml.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using gui.ViewModels;
+using gui.Views;
+
+namespace gui;
+
+public class App : Application
+{
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            var viewModel = new MainWindowViewModel();
+            desktop.MainWindow = new MainWindow { DataContext = viewModel };
+
+            string? initialFile = desktop.Args?.FirstOrDefault(File.Exists);
+            if (initialFile is not null) viewModel.LoadFile(Path.GetFullPath(initialFile));
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/gui/Parsing/LanguageService.cs
+++ b/gui/Parsing/LanguageService.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Antlr4.Runtime;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using src;
+using LspLocation = Microsoft.VisualStudio.LanguageServer.Protocol.Location;
+
+namespace gui.Parsing;
+
+// A span of the source document expressed in char offsets (what the source
+// TextBox works in) plus the 1-based line/column (what humans read).
+public record SourceSpan(int Start, int End, int Line, int Column);
+
+// A goto-definition / find-references hit, with the source line it came from
+// so the results list is readable without jumping to each one.
+public record LocationResult(SourceSpan Span, string Preview)
+{
+    public string Display => $"Line {Span.Line}:{Span.Column}  {Preview}";
+}
+
+public record CompletionEntry(string Label, string Detail)
+{
+    public string Display => string.IsNullOrEmpty(Detail) ? Label : $"{Label}  —  {Detail}";
+}
+
+public record HoverInfo(SourceSpan Span, string Markdown);
+
+// Wraps the language-service logic that backs `nbem --lsp` so the GUI can call
+// it in-process. The LSP handlers in src/Lsp.cs are only JSON-RPC plumbing over
+// LanguageServer.DocumentState, so everything here is the same code path the
+// editor integrations use - the difference is char offsets in, char offsets out,
+// instead of LSP line/character positions.
+public sealed class LanguageService
+{
+    private readonly LanguageServer.DocumentState _document;
+    private readonly string _text;
+    private readonly Uri _uri;
+
+    // Offset of the start of each line, so offset <-> (line, character)
+    // conversion is a binary search rather than a scan of the whole document.
+    private readonly int[] _lineStarts;
+
+    internal LanguageService(LanguageServer.DocumentState document, string text, string filePath)
+    {
+        _document = document;
+        _text = text;
+        _uri = ToUri(filePath);
+        _lineStarts = ComputeLineStarts(text);
+    }
+
+    public IReadOnlyList<LocationResult> FindDefinitions(int offset)
+    {
+        (int line, int character) = ToPosition(offset);
+        return _document.FindDefinitions(_uri, line, character).Select(ToResult).ToList();
+    }
+
+    public IReadOnlyList<LocationResult> FindReferences(int offset, bool includeDeclaration = true)
+    {
+        (int line, int character) = ToPosition(offset);
+        return _document.FindReferences(_uri, line, character, includeDeclaration).Select(ToResult).ToList();
+    }
+
+    public IReadOnlyList<CompletionEntry> FindCompletions(int offset)
+    {
+        (int line, int character) = ToPosition(offset);
+        return _document.FindCompletions(line, character)
+            .Select(item => new CompletionEntry(item.Label ?? "", item.Detail ?? ""))
+            .ToList();
+    }
+
+    public HoverInfo? FindHover(int offset)
+    {
+        IToken? token = FindToken(offset);
+        if (token is null) return null;
+
+        string? markdown = LanguageServer.TryGetBuiltInHoverMarkdown(token.Text);
+        if (markdown is null) return null;
+
+        return new HoverInfo(SpanOfToken(token), markdown);
+    }
+
+    // The token under the caret, used for the status line and to tell the user
+    // why a request came back empty.
+    public IToken? FindToken(int offset)
+    {
+        (int line, int character) = ToPosition(offset);
+        return _document.FindToken(line, character);
+    }
+
+    public static string DescribeTokenType(IToken token) =>
+        NeobemLexer.DefaultVocabulary.GetSymbolicName(token.Type) ?? token.Type.ToString();
+
+    private LocationResult ToResult(LspLocation location) =>
+        new(ToSpan(location.Range), LineTextAt(location.Range.Start.Line));
+
+    private SourceSpan ToSpan(Microsoft.VisualStudio.LanguageServer.Protocol.Range range)
+    {
+        int start = ToOffset(range.Start.Line, range.Start.Character);
+        int end = ToOffset(range.End.Line, range.End.Character);
+        return new SourceSpan(start, Math.Max(start, end), range.Start.Line + 1, range.Start.Character + 1);
+    }
+
+    private SourceSpan SpanOfToken(IToken token) =>
+        new(token.StartIndex, token.StopIndex + 1, token.Line, token.Column + 1);
+
+    private string LineTextAt(int zeroBasedLine)
+    {
+        if (zeroBasedLine < 0 || zeroBasedLine >= _lineStarts.Length) return "";
+        int start = _lineStarts[zeroBasedLine];
+        int end = zeroBasedLine + 1 < _lineStarts.Length ? _lineStarts[zeroBasedLine + 1] : _text.Length;
+        return _text[start..end].TrimEnd('\n', '\r').Trim();
+    }
+
+    // ANTLR counts lines on '\n' only and columns in chars since that newline,
+    // so the conversions here have to do the same or spans land off by the '\r'
+    // count on CRLF files.
+    private static int[] ComputeLineStarts(string text)
+    {
+        List<int> starts = new() { 0 };
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '\n') starts.Add(i + 1);
+        }
+        return starts.ToArray();
+    }
+
+    public (int Line, int Character) ToPosition(int offset)
+    {
+        offset = Math.Clamp(offset, 0, _text.Length);
+        int index = Array.BinarySearch(_lineStarts, offset);
+        int line = index >= 0 ? index : ~index - 1;
+        return (line, offset - _lineStarts[line]);
+    }
+
+    public int ToOffset(int zeroBasedLine, int zeroBasedCharacter)
+    {
+        if (zeroBasedLine < 0) return 0;
+        if (zeroBasedLine >= _lineStarts.Length) return _text.Length;
+
+        int lineEnd = zeroBasedLine + 1 < _lineStarts.Length ? _lineStarts[zeroBasedLine + 1] : _text.Length;
+        return Math.Clamp(_lineStarts[zeroBasedLine] + zeroBasedCharacter, 0, lineEnd);
+    }
+
+    private static Uri ToUri(string filePath)
+    {
+        try
+        {
+            return new Uri(System.IO.Path.GetFullPath(filePath));
+        }
+        catch (Exception)
+        {
+            // Unsaved or odd paths still need *some* uri - definitions are
+            // all within the one document, so its exact value does not matter.
+            return new Uri("untitled:document");
+        }
+    }
+}

--- a/gui/Parsing/NeobemDocument.cs
+++ b/gui/Parsing/NeobemDocument.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Antlr4.Runtime;
+using src;
+
+namespace gui.Parsing;
+
+public record Diagnostic(int Line, int Column, string Message, string Source)
+{
+    public string Display => $"[{Source}] Line {Line}:{Column} {Message}";
+}
+
+// Result of parsing a single .nbem file: source text, structure tree, and any
+// lexer/parser diagnostics. Parsing never throws on bad input - whatever
+// parses shows up in Symbols, the rest shows up in Diagnostics.
+public class NeobemDocument
+{
+    public string FilePath { get; }
+    public string SourceText { get; }
+    public List<Diagnostic> Diagnostics { get; } = new();
+    public List<SymbolNode> Symbols { get; private set; } = new();
+
+    public static NeobemDocument ParseFile(string filePath) =>
+        new(filePath, File.ReadAllText(filePath));
+
+    public NeobemDocument(string filePath, string sourceText)
+    {
+        FilePath = filePath;
+        SourceText = sourceText;
+
+        var lexer = new NeobemLexer(new AntlrInputStream(sourceText)) { FileType = FileType.Idf };
+        lexer.RemoveErrorListeners();
+        var lexerErrors = new SimpleAntlrErrorListener();
+        lexer.AddErrorListener(lexerErrors);
+
+        var tokens = new CommonTokenStream(lexer);
+        var parser = new NeobemParser(tokens);
+        parser.RemoveErrorListeners();
+        var parserErrors = new SimpleAntlrErrorListener();
+        parser.AddErrorListener(parserErrors);
+
+        NeobemParser.IdfContext tree = parser.idf();
+
+        Diagnostics.AddRange(lexerErrors.Errors.Select(e => new Diagnostic(e.Line, e.CharPositionInLine, e.Msg, "lexer")));
+        Diagnostics.AddRange(parserErrors.Errors.Select(e => new Diagnostic(e.Line, e.CharPositionInLine, e.Msg, "parser")));
+
+        Symbols = StructureWalker.Walk(tree);
+    }
+}

--- a/gui/Parsing/NeobemDocument.cs
+++ b/gui/Parsing/NeobemDocument.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Antlr4.Runtime;
 using src;
 
 namespace gui.Parsing;
@@ -21,6 +20,10 @@ public class NeobemDocument
     public List<Diagnostic> Diagnostics { get; } = new();
     public List<SymbolNode> Symbols { get; private set; } = new();
 
+    // Goto-definition, references, hover and completion, backed by the same
+    // code as `nbem --lsp`.
+    public LanguageService Language { get; }
+
     public static NeobemDocument ParseFile(string filePath) =>
         new(filePath, File.ReadAllText(filePath));
 
@@ -29,22 +32,30 @@ public class NeobemDocument
         FilePath = filePath;
         SourceText = sourceText;
 
-        var lexer = new NeobemLexer(new AntlrInputStream(sourceText)) { FileType = FileType.Idf };
-        lexer.RemoveErrorListeners();
-        var lexerErrors = new SimpleAntlrErrorListener();
-        lexer.AddErrorListener(lexerErrors);
+        // The LSP document state parses the file and builds the definition,
+        // reference and completion indexes in one pass, so the GUI parses once
+        // and gets both the structure tree and the language features from it.
+        LanguageServer.LoggingEnabled = false;
+        LanguageServer.DocumentState state = new(sourceText, DetermineFileType(filePath));
 
-        var tokens = new CommonTokenStream(lexer);
-        var parser = new NeobemParser(tokens);
-        parser.RemoveErrorListeners();
-        var parserErrors = new SimpleAntlrErrorListener();
-        parser.AddErrorListener(parserErrors);
+        Diagnostics.AddRange(state.LexerErrors.Select(e => new Diagnostic(e.Line, e.CharPositionInLine, e.Msg, "lexer")));
+        Diagnostics.AddRange(state.ParserErrors.Select(e => new Diagnostic(e.Line, e.CharPositionInLine, e.Msg, "parser")));
+        if (state.LastParseException is not null)
+        {
+            Diagnostics.Add(new Diagnostic(1, 0, state.LastParseException.Message, "parser"));
+        }
 
-        NeobemParser.IdfContext tree = parser.idf();
-
-        Diagnostics.AddRange(lexerErrors.Errors.Select(e => new Diagnostic(e.Line, e.CharPositionInLine, e.Msg, "lexer")));
-        Diagnostics.AddRange(parserErrors.Errors.Select(e => new Diagnostic(e.Line, e.CharPositionInLine, e.Msg, "parser")));
-
-        Symbols = StructureWalker.Walk(tree);
+        Symbols = state.ParseTree is null ? new List<SymbolNode>() : StructureWalker.Walk(state.ParseTree);
+        Language = new LanguageService(state, sourceText, filePath);
     }
+
+    // Matches the language server's rule, so the GUI lexes a .inp/.bdl file the
+    // same way an editor would.
+    private static FileType DetermineFileType(string filePath) =>
+        Path.GetExtension(filePath).ToLowerInvariant() switch
+        {
+            ".bdl" => FileType.Doe2,
+            ".inp" => FileType.Doe2,
+            _ => FileType.Idf,
+        };
 }

--- a/gui/Parsing/StructureWalker.cs
+++ b/gui/Parsing/StructureWalker.cs
@@ -1,0 +1,208 @@
+using System.Collections.Generic;
+using System.Linq;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Antlr4.Runtime.Tree;
+using src;
+
+namespace gui.Parsing;
+
+// Walks a Neobem parse tree and produces the source structure tree shown in
+// the GUI. Deliberately GUI-agnostic so it can later back an LSP
+// textDocument/documentSymbol implementation.
+public static class StructureWalker
+{
+    public static List<SymbolNode> Walk(NeobemParser.IdfContext idf)
+    {
+        var result = new List<SymbolNode>();
+        foreach (NeobemParser.Base_idfContext statement in idf.base_idf())
+        {
+            switch (statement)
+            {
+                case NeobemParser.ObjectDeclarationContext c:
+                    result.Add(FromObject(c.@object()));
+                    break;
+                case NeobemParser.Doe2ObjectDeclarationContext c:
+                    result.Add(FromDoe2Object(c.doe2object()));
+                    break;
+                case NeobemParser.VariableDeclarationContext c:
+                    result.Add(FromVariableDeclaration(c.variable_declaration()));
+                    break;
+                case NeobemParser.ImportStatementContext c:
+                    result.Add(FromImport(c.import_statement()));
+                    break;
+                case NeobemParser.ExportStatmentContext c:
+                    result.Add(FromExport(c.export_statement()));
+                    break;
+                case NeobemParser.PrintStatmentContext c:
+                    result.Add(FromSimple(SymbolKind.Print, "print", c.print_statment().expression(), c.print_statment()));
+                    break;
+                case NeobemParser.LogStatementContext c:
+                    result.Add(FromSimple(SymbolKind.Log, "log", c.log_statement().expression(), c.log_statement()));
+                    break;
+                // Comments are skipped.
+            }
+        }
+        return result;
+    }
+
+    private static SymbolNode FromObject(NeobemParser.ObjectContext ctx)
+    {
+        string name = ctx.OBJECT_TYPE().GetText().Trim();
+        ITerminalNode[] fields = ctx.FIELD();
+        string detail = fields.Length > 0 ? Truncate(fields[0].GetText().Trim(), 40) : "";
+        return Node(SymbolKind.Object, name, detail, ctx);
+    }
+
+    private static SymbolNode FromDoe2Object(NeobemParser.Doe2objectContext ctx)
+    {
+        string name = (ctx.DOE2IDENTIFIER() ?? ctx.DOE2STRING_UNAME())?.GetText().Trim() ?? "DOE-2 object";
+        return Node(SymbolKind.Doe2Object, name, "", ctx);
+    }
+
+    private static SymbolNode FromVariableDeclaration(NeobemParser.Variable_declarationContext ctx)
+    {
+        string name = ctx.IDENTIFIER().GetText();
+        NeobemParser.ExpressionContext expr = ctx.expression();
+
+        if (expr is NeobemParser.LambdaExpContext lambdaExp)
+        {
+            NeobemParser.Lambda_defContext lambda = lambdaExp.lambda_def();
+            return Node(SymbolKind.Function, name, LambdaParams(lambda), ctx, CollectNested(LambdaBody(lambda)));
+        }
+
+        return Node(SymbolKind.Variable, name, Truncate(SourceText(expr), 40), ctx, CollectNested(expr));
+    }
+
+    private static SymbolNode FromImport(NeobemParser.Import_statementContext ctx)
+    {
+        string name = StripQuotes(ctx.expression().GetText());
+        string detail = string.Join(" ", ctx.import_option().Select(o => SourceText(o)));
+        return Node(SymbolKind.Import, name, detail, ctx);
+    }
+
+    private static SymbolNode FromExport(NeobemParser.Export_statementContext ctx)
+    {
+        string detail = string.Join(", ", ctx.IDENTIFIER().Select(i => i.GetText()));
+        return Node(SymbolKind.Export, "export", detail, ctx);
+    }
+
+    private static SymbolNode FromSimple(SymbolKind kind, string name, NeobemParser.ExpressionContext expr, ParserRuleContext ctx) =>
+        Node(kind, name, Truncate(SourceText(expr), 40), ctx, CollectNested(expr));
+
+    private static SymbolNode FromLambda(string name, NeobemParser.Lambda_defContext ctx) =>
+        Node(SymbolKind.Function, name, LambdaParams(ctx), ctx, CollectNested(LambdaBody(ctx)));
+
+    private static SymbolNode FromIdfPlusObject(NeobemParser.Idfplus_objectContext ctx)
+    {
+        NeobemParser.Idfplus_object_property_defContext[] props = ctx.idfplus_object_property_def();
+        string detail = props.Length > 0
+            ? Truncate(string.Join(", ", props.Select(p => StripQuotes(p.expression(0).GetText()))), 40)
+            : "";
+        var children = new List<SymbolNode>();
+        foreach (NeobemParser.Idfplus_object_property_defContext prop in props)
+            Collect(prop.expression(1), children);
+        return Node(SymbolKind.IdfPlusObject, "object", detail, ctx, children);
+    }
+
+    private static SymbolNode FromLet(NeobemParser.Let_bindingContext ctx)
+    {
+        var children = new List<SymbolNode>();
+        ITerminalNode[] names = ctx.IDENTIFIER();
+        NeobemParser.ExpressionContext[] exprs = ctx.expression();
+        for (int i = 0; i < names.Length && i < exprs.Length; i++)
+        {
+            children.Add(Node(SymbolKind.Variable, names[i].GetText(), Truncate(SourceText(exprs[i]), 40),
+                Span(names[i].Symbol, exprs[i].Stop), CollectNested(exprs[i])));
+        }
+        Collect(ctx.let_expression(), children);
+        return Node(SymbolKind.Let, "let", string.Join(", ", names.Select(n => n.GetText())), ctx, children);
+    }
+
+    // Recursive descent that stops at any construct that gets its own node,
+    // so nesting in the tree mirrors nesting in the source.
+    private static void Collect(IParseTree tree, List<SymbolNode> sink)
+    {
+        switch (tree)
+        {
+            case NeobemParser.Variable_declarationContext c:
+                sink.Add(FromVariableDeclaration(c));
+                return;
+            case NeobemParser.Lambda_defContext c:
+                sink.Add(FromLambda("λ", c));
+                return;
+            case NeobemParser.Idfplus_objectContext c:
+                sink.Add(FromIdfPlusObject(c));
+                return;
+            case NeobemParser.Let_bindingContext c:
+                sink.Add(FromLet(c));
+                return;
+            case NeobemParser.ObjectContext c:
+                sink.Add(FromObject(c));
+                return;
+            case NeobemParser.Doe2objectContext c:
+                sink.Add(FromDoe2Object(c));
+                return;
+            case ParserRuleContext ctx:
+                for (int i = 0; i < ctx.ChildCount; i++) Collect(ctx.GetChild(i), sink);
+                return;
+        }
+    }
+
+    private static List<SymbolNode> CollectNested(IEnumerable<IParseTree> trees)
+    {
+        var result = new List<SymbolNode>();
+        foreach (IParseTree tree in trees) Collect(tree, result);
+        return result;
+    }
+
+    private static List<SymbolNode> CollectNested(IParseTree tree) => CollectNested(new[] { tree });
+
+    private static IEnumerable<IParseTree> LambdaBody(NeobemParser.Lambda_defContext ctx)
+    {
+        if (ctx.expression() is { } expr) yield return expr;
+        foreach (NeobemParser.Function_statementContext statement in ctx.function_statement()) yield return statement;
+    }
+
+    private static string LambdaParams(NeobemParser.Lambda_defContext ctx) =>
+        "λ " + string.Join(" ", ctx.IDENTIFIER().Select(i => i.GetText()));
+
+    private static SymbolNode Node(SymbolKind kind, string name, string detail, ParserRuleContext ctx, List<SymbolNode>? children = null) =>
+        Node(kind, name, detail, (ctx.Start.Line, ctx.Start.StartIndex, ctx.Stop?.StopIndex ?? ctx.Start.StopIndex), children);
+
+    private static SymbolNode Node(SymbolKind kind, string name, string detail, (int Line, int Start, int Stop) span, List<SymbolNode>? children = null) =>
+        new()
+        {
+            Kind = kind,
+            Name = name,
+            Detail = detail,
+            Line = span.Line,
+            StartIndex = span.Start,
+            StopIndex = span.Stop,
+            Children = children ?? new List<SymbolNode>(),
+        };
+
+    // GetText() concatenates tokens with whitespace stripped; this reads the
+    // original source span so details render as written.
+    private static string SourceText(ParserRuleContext ctx) =>
+        ctx.Start.InputStream is { } stream && ctx.Stop is not null
+            ? stream.GetText(new Interval(ctx.Start.StartIndex, ctx.Stop.StopIndex))
+            : ctx.GetText();
+
+    private static (int, int, int) Span(IToken start, IToken? stop) =>
+        (start.Line, start.StartIndex, stop?.StopIndex ?? start.StopIndex);
+
+    private static string StripQuotes(string s)
+    {
+        s = s.Trim();
+        if (s.Length >= 2 && (s[0] == '\'' && s[^1] == '\'' || s[0] == '"' && s[^1] == '"'))
+            return s[1..^1];
+        return s;
+    }
+
+    private static string Truncate(string s, int max)
+    {
+        s = s.Replace("\r", "").Replace("\n", " ");
+        return s.Length <= max ? s : s[..(max - 1)] + "…";
+    }
+}

--- a/gui/Parsing/SymbolNode.cs
+++ b/gui/Parsing/SymbolNode.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace gui.Parsing;
+
+public enum SymbolKind
+{
+    Object,
+    Doe2Object,
+    IdfPlusObject,
+    Variable,
+    Function,
+    Import,
+    Export,
+    Print,
+    Log,
+    Let,
+    Return,
+}
+
+// One node in the source structure tree. Spans are 0-based char offsets into
+// the original source text; Line is 1-based to match ANTLR/editor conventions.
+public class SymbolNode
+{
+    public SymbolKind Kind { get; init; }
+    public string Name { get; init; } = "";
+    public string Detail { get; init; } = "";
+    public int Line { get; init; }
+    public int StartIndex { get; init; }
+    public int StopIndex { get; init; }
+    public List<SymbolNode> Children { get; init; } = new();
+
+    public string Glyph => Kind switch
+    {
+        SymbolKind.Object => "OBJ",
+        SymbolKind.Doe2Object => "DOE2",
+        SymbolKind.IdfPlusObject => "{ }",
+        SymbolKind.Variable => "VAR",
+        SymbolKind.Function => "FN",
+        SymbolKind.Import => "IMP",
+        SymbolKind.Export => "EXP",
+        SymbolKind.Print => "PRN",
+        SymbolKind.Log => "LOG",
+        SymbolKind.Let => "LET",
+        SymbolKind.Return => "RET",
+        _ => "?",
+    };
+}

--- a/gui/Program.cs
+++ b/gui/Program.cs
@@ -27,7 +27,53 @@ internal static class Program
             return doc.Diagnostics.Count == 0 ? 0 : 1;
         }
 
+        // Headless probe of the language features the GUI exposes, so they can
+        // be smoke tested without a display.
+        if (args.Contains("--query"))
+        {
+            string[] rest = args.Where(a => a != "--query").ToArray();
+            if (rest.Length != 2 || !File.Exists(rest[0]) || !TryParsePosition(rest[1], out int line, out int column))
+            {
+                Console.Error.Write("usage: nbem-gui --query <file.nbem> <line>:<column>\n");
+                return 1;
+            }
+            return Query(rest[0], line, column);
+        }
+
         return BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    private static bool TryParsePosition(string text, out int line, out int column)
+    {
+        line = column = 0;
+        string[] parts = text.Split(':');
+        return parts.Length == 2 && int.TryParse(parts[0], out line) && int.TryParse(parts[1], out column);
+    }
+
+    // Prints, for a 1-based line:column, everything the GUI would show for that
+    // caret position.
+    private static int Query(string file, int line, int column)
+    {
+        NeobemDocument doc = NeobemDocument.ParseFile(file);
+        LanguageService language = doc.Language;
+        int offset = language.ToOffset(line - 1, column - 1);
+
+        Antlr4.Runtime.IToken? token = language.FindToken(offset);
+        Console.Write($"token: {(token is null ? "(none)" : $"{LanguageService.DescribeTokenType(token)} '{token.Text?.Trim()}'")}\n");
+
+        HoverInfo? hover = language.FindHover(offset);
+        Console.Write($"hover: {(hover is null ? "(none)" : hover.Markdown.Replace("\n", " "))}\n");
+
+        Console.Write("definitions:\n");
+        foreach (LocationResult definition in language.FindDefinitions(offset)) Console.Write($"  {definition.Display}\n");
+
+        Console.Write("references:\n");
+        foreach (LocationResult reference in language.FindReferences(offset)) Console.Write($"  {reference.Display}\n");
+
+        Console.Write("completions:\n");
+        foreach (CompletionEntry completion in language.FindCompletions(offset)) Console.Write($"  {completion.Display}\n");
+
+        return 0;
     }
 
     private static void Dump(SymbolNode node, int depth)

--- a/gui/Program.cs
+++ b/gui/Program.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Linq;
+using Avalonia;
+using gui.Parsing;
+
+namespace gui;
+
+internal static class Program
+{
+    [STAThread]
+    public static int Main(string[] args)
+    {
+        // Headless mode for smoke testing and scripting: print the structure
+        // tree to stdout instead of launching the GUI.
+        if (args.Contains("--dump"))
+        {
+            string? file = args.FirstOrDefault(a => a != "--dump");
+            if (file is null || !File.Exists(file))
+            {
+                Console.Error.Write("usage: nbem-gui --dump <file.nbem>\n");
+                return 1;
+            }
+            NeobemDocument doc = NeobemDocument.ParseFile(file);
+            foreach (Diagnostic diagnostic in doc.Diagnostics) Console.Error.Write(diagnostic.Display + "\n");
+            foreach (SymbolNode symbol in doc.Symbols) Dump(symbol, 0);
+            return doc.Diagnostics.Count == 0 ? 0 : 1;
+        }
+
+        return BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    private static void Dump(SymbolNode node, int depth)
+    {
+        Console.Write($"{new string(' ', depth * 2)}{node.Glyph,-4} {node.Name} {node.Detail} (line {node.Line})\n");
+        foreach (SymbolNode child in node.Children) Dump(child, depth + 1);
+    }
+
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+}

--- a/gui/ViewModels/MainWindowViewModel.cs
+++ b/gui/ViewModels/MainWindowViewModel.cs
@@ -17,11 +17,25 @@ public partial class MainWindowViewModel : ObservableObject
     [ObservableProperty] private SymbolNode? _selectedSymbol;
     [ObservableProperty] private string _statusText = "Open a .nbem file to begin.";
 
+    [ObservableProperty] private string _resultsTitle = "";
+    [ObservableProperty] private string _hoverMarkdown = "";
+    [ObservableProperty] private string _caretInfo = "";
+
     public ObservableCollection<SymbolNode> RootSymbols { get; } = new();
     public ObservableCollection<Diagnostic> Diagnostics { get; } = new();
     public bool HasDiagnostics => Diagnostics.Count > 0;
 
+    // Goto-definition / find-references hits and completion candidates for the
+    // current caret position. Only one of the two is populated at a time.
+    public ObservableCollection<LocationResult> Results { get; } = new();
+    public ObservableCollection<CompletionEntry> Completions { get; } = new();
+    public bool HasResults => Results.Count > 0;
+    public bool HasCompletions => Completions.Count > 0;
+    public bool HasResultsPane => HasResults || HasCompletions;
+    public bool HasHover => HoverMarkdown.Length > 0;
+
     private List<SymbolNode> _allSymbols = new();
+    private LanguageService? _language;
     private FileSystemWatcher? _watcher;
     private DispatcherTimer? _reloadDebounce;
 
@@ -40,6 +54,10 @@ public partial class MainWindowViewModel : ObservableObject
             NeobemDocument doc = NeobemDocument.ParseFile(FilePath);
             SourceText = doc.SourceText;
             _allSymbols = doc.Symbols;
+            _language = doc.Language;
+
+            // Offsets in the old text mean nothing after a reload.
+            ClearResults();
 
             Diagnostics.Clear();
             foreach (Diagnostic diagnostic in doc.Diagnostics) Diagnostics.Add(diagnostic);
@@ -57,6 +75,114 @@ public partial class MainWindowViewModel : ObservableObject
     }
 
     partial void OnFilterTextChanged(string value) => ApplyFilter();
+
+    // ---- Language features -------------------------------------------------
+    // All of these take a char offset into SourceText (the source pane's caret)
+    // and delegate to the same language service that backs `nbem --lsp`.
+
+    // Returns the span to navigate to when there is exactly one definition;
+    // with several, they land in the results pane for the user to pick.
+    public SourceSpan? GoToDefinition(int offset)
+    {
+        if (_language is null) return null;
+        ClearResults();
+
+        IReadOnlyList<LocationResult> definitions = _language.FindDefinitions(offset);
+        if (definitions.Count == 0)
+        {
+            StatusText = $"No definition found for {DescribeCaret(offset)}.";
+            return null;
+        }
+
+        if (definitions.Count == 1)
+        {
+            StatusText = $"Definition: line {definitions[0].Span.Line}.";
+            return definitions[0].Span;
+        }
+
+        ShowResults($"{definitions.Count} definitions", definitions);
+        return definitions[0].Span;
+    }
+
+    public void FindReferences(int offset)
+    {
+        if (_language is null) return;
+        ClearResults();
+
+        IReadOnlyList<LocationResult> references = _language.FindReferences(offset, includeDeclaration: true);
+        if (references.Count == 0)
+        {
+            StatusText = $"No references found for {DescribeCaret(offset)}.";
+            return;
+        }
+
+        ShowResults($"{references.Count} references", references);
+    }
+
+    // The source pane is read-only, so completions are shown as the set of
+    // values EnergyPlus accepts in the field under the caret rather than as an
+    // insertion popup.
+    public void ShowCompletions(int offset)
+    {
+        if (_language is null) return;
+        ClearResults();
+
+        IReadOnlyList<CompletionEntry> completions = _language.FindCompletions(offset);
+        if (completions.Count == 0)
+        {
+            StatusText = $"No completions available at {DescribeCaret(offset)}.";
+            return;
+        }
+
+        foreach (CompletionEntry entry in completions) Completions.Add(entry);
+        ResultsTitle = $"{completions.Count} valid values";
+        RaiseResultsChanged();
+        StatusText = ResultsTitle + " for the field under the caret.";
+    }
+
+    // Hover is driven by the caret rather than the mouse: the source pane is a
+    // plain TextBox with no character hit-testing.
+    public void UpdateCaret(int offset)
+    {
+        if (_language is null) return;
+
+        HoverInfo? hover = _language.FindHover(offset);
+        HoverMarkdown = hover?.Markdown ?? "";
+        OnPropertyChanged(nameof(HasHover));
+        CaretInfo = DescribeCaret(offset);
+    }
+
+    private string DescribeCaret(int offset)
+    {
+        if (_language is null) return "";
+        (int line, int character) = _language.ToPosition(offset);
+        Antlr4.Runtime.IToken? token = _language.FindToken(offset);
+        string where = $"line {line + 1}:{character + 1}";
+        return token is null ? where : $"{where} ({LanguageService.DescribeTokenType(token)} '{token.Text?.Trim()}')";
+    }
+
+    private void ShowResults(string title, IEnumerable<LocationResult> results)
+    {
+        foreach (LocationResult result in results) Results.Add(result);
+        ResultsTitle = title;
+        RaiseResultsChanged();
+        StatusText = title + ".";
+    }
+
+    public void ClearResults()
+    {
+        Results.Clear();
+        Completions.Clear();
+        ResultsTitle = "";
+        RaiseResultsChanged();
+    }
+
+    private void RaiseResultsChanged()
+    {
+        OnPropertyChanged(nameof(HasResults));
+        OnPropertyChanged(nameof(HasCompletions));
+        OnPropertyChanged(nameof(HasResultsPane));
+    }
 
     private void ApplyFilter()
     {

--- a/gui/ViewModels/MainWindowViewModel.cs
+++ b/gui/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using gui.Parsing;
+
+namespace gui.ViewModels;
+
+public partial class MainWindowViewModel : ObservableObject
+{
+    [ObservableProperty] private string? _filePath;
+    [ObservableProperty] private string _sourceText = "";
+    [ObservableProperty] private string _filterText = "";
+    [ObservableProperty] private SymbolNode? _selectedSymbol;
+    [ObservableProperty] private string _statusText = "Open a .nbem file to begin.";
+
+    public ObservableCollection<SymbolNode> RootSymbols { get; } = new();
+    public ObservableCollection<Diagnostic> Diagnostics { get; } = new();
+    public bool HasDiagnostics => Diagnostics.Count > 0;
+
+    private List<SymbolNode> _allSymbols = new();
+    private FileSystemWatcher? _watcher;
+    private DispatcherTimer? _reloadDebounce;
+
+    public void LoadFile(string path)
+    {
+        FilePath = path;
+        Reload();
+        WatchFile(path);
+    }
+
+    public void Reload()
+    {
+        if (FilePath is null) return;
+        try
+        {
+            NeobemDocument doc = NeobemDocument.ParseFile(FilePath);
+            SourceText = doc.SourceText;
+            _allSymbols = doc.Symbols;
+
+            Diagnostics.Clear();
+            foreach (Diagnostic diagnostic in doc.Diagnostics) Diagnostics.Add(diagnostic);
+            OnPropertyChanged(nameof(HasDiagnostics));
+
+            ApplyFilter();
+            StatusText = $"{Path.GetFileName(FilePath)} — {CountNodes(_allSymbols)} symbols" +
+                         (doc.Diagnostics.Count > 0 ? $", {doc.Diagnostics.Count} parse errors" : "") +
+                         $" — reloaded {DateTime.Now:HH:mm:ss}";
+        }
+        catch (Exception e)
+        {
+            StatusText = $"Failed to load {FilePath}: {e.Message}";
+        }
+    }
+
+    partial void OnFilterTextChanged(string value) => ApplyFilter();
+
+    private void ApplyFilter()
+    {
+        RootSymbols.Clear();
+        foreach (SymbolNode node in _allSymbols)
+        {
+            SymbolNode? filtered = Filter(node, FilterText.Trim());
+            if (filtered is not null) RootSymbols.Add(filtered);
+        }
+    }
+
+    // A node matching the filter keeps its whole subtree; a non-matching node
+    // survives only if some descendant matches.
+    private static SymbolNode? Filter(SymbolNode node, string filter)
+    {
+        if (filter.Length == 0) return node;
+        bool selfMatch = node.Name.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                         node.Detail.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                         node.Glyph.Contains(filter, StringComparison.OrdinalIgnoreCase);
+        if (selfMatch) return node;
+
+        List<SymbolNode> children = node.Children
+            .Select(c => Filter(c, filter))
+            .Where(c => c is not null)
+            .Cast<SymbolNode>()
+            .ToList();
+        if (children.Count == 0) return null;
+
+        return new SymbolNode
+        {
+            Kind = node.Kind,
+            Name = node.Name,
+            Detail = node.Detail,
+            Line = node.Line,
+            StartIndex = node.StartIndex,
+            StopIndex = node.StopIndex,
+            Children = children,
+        };
+    }
+
+    private static int CountNodes(IEnumerable<SymbolNode> nodes) =>
+        nodes.Sum(n => 1 + CountNodes(n.Children));
+
+    // Auto-reload when the file changes on disk, so the GUI acts as a live
+    // outline next to a real editor. Watching can fail on some filesystems
+    // (e.g. network mounts) - in that case manual Reload still works.
+    private void WatchFile(string path)
+    {
+        _watcher?.Dispose();
+        _watcher = null;
+        try
+        {
+            string? dir = Path.GetDirectoryName(path);
+            if (dir is null) return;
+            _watcher = new FileSystemWatcher(dir, Path.GetFileName(path))
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
+                EnableRaisingEvents = true,
+            };
+            _watcher.Changed += OnFileChanged;
+            _watcher.Created += OnFileChanged;
+            _watcher.Renamed += OnFileChanged;
+        }
+        catch (Exception)
+        {
+            _watcher = null;
+        }
+    }
+
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            _reloadDebounce ??= new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(300) };
+            _reloadDebounce.Tick -= ReloadTick;
+            _reloadDebounce.Tick += ReloadTick;
+            _reloadDebounce.Stop();
+            _reloadDebounce.Start();
+        });
+    }
+
+    private void ReloadTick(object? sender, EventArgs e)
+    {
+        _reloadDebounce?.Stop();
+        Reload();
+    }
+}

--- a/gui/Views/MainWindow.axaml
+++ b/gui/Views/MainWindow.axaml
@@ -1,0 +1,100 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:gui.ViewModels"
+        xmlns:p="using:gui.Parsing"
+        x:Class="gui.Views.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
+        Title="Neobem Explorer"
+        Width="1200" Height="800">
+
+  <DockPanel>
+
+    <!-- Toolbar -->
+    <Border DockPanel.Dock="Top" Padding="8,6" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="0,0,0,1">
+      <DockPanel>
+        <StackPanel Orientation="Horizontal" Spacing="6" DockPanel.Dock="Left">
+          <Button Content="Open…" Click="OpenClicked" />
+          <Button Content="Reload" Click="ReloadClicked" />
+          <TextBox Width="220" Watermark="Filter symbols…" Text="{Binding FilterText, Mode=TwoWay}" />
+        </StackPanel>
+        <TextBlock Text="{Binding FilePath}" VerticalAlignment="Center" Margin="12,0,0,0"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" TextTrimming="CharacterEllipsis" />
+      </DockPanel>
+    </Border>
+
+    <!-- Status bar -->
+    <Border DockPanel.Dock="Bottom" Padding="8,4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="0,1,0,0">
+      <TextBlock Text="{Binding StatusText}" FontSize="12"
+                 Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+    </Border>
+
+    <!-- Diagnostics -->
+    <Border DockPanel.Dock="Bottom" MaxHeight="140" IsVisible="{Binding HasDiagnostics}"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="0,1,0,0">
+      <ListBox ItemsSource="{Binding Diagnostics}" DoubleTapped="DiagnosticDoubleTapped" FontSize="12">
+        <ListBox.ItemTemplate>
+          <DataTemplate x:DataType="p:Diagnostic">
+            <TextBlock Text="{Binding Display}" Foreground="IndianRed" />
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </Border>
+
+    <!-- Main panes -->
+    <Grid ColumnDefinitions="300,4,*,4,260">
+
+      <!-- Structure tree -->
+      <TreeView Grid.Column="0" x:Name="SymbolTree"
+                ItemsSource="{Binding RootSymbols}"
+                SelectionChanged="SymbolTreeSelectionChanged">
+        <TreeView.Styles>
+          <Style Selector="TreeViewItem">
+            <Setter Property="IsExpanded" Value="True" />
+          </Style>
+        </TreeView.Styles>
+        <TreeView.ItemTemplate>
+          <TreeDataTemplate ItemsSource="{Binding Children}" x:DataType="p:SymbolNode">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+              <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}" CornerRadius="3" Padding="4,0">
+                <TextBlock Text="{Binding Glyph}" FontSize="11" VerticalAlignment="Center" />
+              </Border>
+              <TextBlock Text="{Binding Name}" FontWeight="SemiBold" VerticalAlignment="Center" />
+              <TextBlock Text="{Binding Detail}" FontSize="12" VerticalAlignment="Center"
+                         Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+            </StackPanel>
+          </TreeDataTemplate>
+        </TreeView.ItemTemplate>
+      </TreeView>
+
+      <GridSplitter Grid.Column="1" ResizeDirection="Columns" Background="Transparent" />
+
+      <!-- Source view -->
+      <TextBox Grid.Column="2" x:Name="SourceBox"
+               Text="{Binding SourceText}"
+               IsReadOnly="True" AcceptsReturn="True" TextWrapping="NoWrap"
+               FontFamily="Cascadia Mono,Consolas,DejaVu Sans Mono,Menlo,monospace" FontSize="13"
+               ScrollViewer.HorizontalScrollBarVisibility="Auto"
+               ScrollViewer.VerticalScrollBarVisibility="Auto" />
+
+      <GridSplitter Grid.Column="3" ResizeDirection="Columns" Background="Transparent" />
+
+      <!-- Detail pane -->
+      <StackPanel Grid.Column="4" Margin="10" Spacing="8">
+        <TextBlock Text="Selected symbol" FontWeight="Bold" />
+        <StackPanel IsVisible="{Binding SelectedSymbol, Converter={x:Static ObjectConverters.IsNotNull}}" Spacing="4">
+          <TextBlock Text="{Binding SelectedSymbol.Name, FallbackValue=''}" FontSize="16" FontWeight="SemiBold" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding SelectedSymbol.Kind, FallbackValue=''}" />
+          <TextBlock Text="{Binding SelectedSymbol.Detail, FallbackValue=''}" TextWrapping="Wrap"
+                     Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+          <TextBlock Text="{Binding SelectedSymbol.Line, StringFormat='Line {0}', FallbackValue=''}" FontSize="12" />
+        </StackPanel>
+        <TextBlock Text="Nothing selected." FontSize="12"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                   IsVisible="{Binding SelectedSymbol, Converter={x:Static ObjectConverters.IsNull}}" />
+      </StackPanel>
+
+    </Grid>
+
+  </DockPanel>
+
+</Window>

--- a/gui/Views/MainWindow.axaml
+++ b/gui/Views/MainWindow.axaml
@@ -5,7 +5,8 @@
         x:Class="gui.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="Neobem Explorer"
-        Width="1200" Height="800">
+        Width="1200" Height="800"
+        KeyDown="WindowKeyDown">
 
   <DockPanel>
 
@@ -16,6 +17,9 @@
           <Button Content="Open…" Click="OpenClicked" />
           <Button Content="Reload" Click="ReloadClicked" />
           <TextBox Width="220" Watermark="Filter symbols…" Text="{Binding FilterText, Mode=TwoWay}" />
+          <Button Content="Definition (F12)" Click="DefinitionClicked" />
+          <Button Content="References (⇧F12)" Click="ReferencesClicked" />
+          <Button Content="Values (Ctrl+Space)" Click="CompletionsClicked" />
         </StackPanel>
         <TextBlock Text="{Binding FilePath}" VerticalAlignment="Center" Margin="12,0,0,0"
                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" TextTrimming="CharacterEllipsis" />
@@ -26,6 +30,35 @@
     <Border DockPanel.Dock="Bottom" Padding="8,4" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="0,1,0,0">
       <TextBlock Text="{Binding StatusText}" FontSize="12"
                  Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+    </Border>
+
+    <!-- Language feature results: definitions, references, or completions -->
+    <Border DockPanel.Dock="Bottom" MaxHeight="180" IsVisible="{Binding HasResultsPane}"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="0,1,0,0">
+      <DockPanel>
+        <Border DockPanel.Dock="Top" Padding="8,4">
+          <DockPanel>
+            <Button DockPanel.Dock="Right" Content="✕" Click="CloseResultsClicked" Padding="6,0" />
+            <TextBlock Text="{Binding ResultsTitle}" FontWeight="SemiBold" VerticalAlignment="Center" />
+          </DockPanel>
+        </Border>
+        <ListBox x:Name="ResultList" ItemsSource="{Binding Results}" IsVisible="{Binding HasResults}"
+                 SelectionChanged="ResultSelectionChanged" FontSize="12"
+                 FontFamily="Cascadia Mono,Consolas,DejaVu Sans Mono,Menlo,monospace">
+          <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="p:LocationResult">
+              <TextBlock Text="{Binding Display}" />
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+        <ListBox ItemsSource="{Binding Completions}" IsVisible="{Binding HasCompletions}" FontSize="12">
+          <ListBox.ItemTemplate>
+            <DataTemplate x:DataType="p:CompletionEntry">
+              <TextBlock Text="{Binding Display}" />
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+      </DockPanel>
     </Border>
 
     <!-- Diagnostics -->
@@ -91,6 +124,17 @@
         <TextBlock Text="Nothing selected." FontSize="12"
                    Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                    IsVisible="{Binding SelectedSymbol, Converter={x:Static ObjectConverters.IsNull}}" />
+
+        <!-- Hover / caret info for the source pane -->
+        <Separator Margin="0,4" />
+        <TextBlock Text="At caret" FontWeight="Bold" />
+        <TextBlock Text="{Binding CaretInfo}" FontSize="12" TextWrapping="Wrap"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+        <Border IsVisible="{Binding HasHover}" Padding="8" CornerRadius="3"
+                Background="{DynamicResource SystemControlBackgroundBaseLowBrush}">
+          <TextBlock Text="{Binding HoverMarkdown}" TextWrapping="Wrap" FontSize="12"
+                     FontFamily="Cascadia Mono,Consolas,DejaVu Sans Mono,Menlo,monospace" />
+        </Border>
       </StackPanel>
 
     </Grid>

--- a/gui/Views/MainWindow.axaml.cs
+++ b/gui/Views/MainWindow.axaml.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using gui.Parsing;
+using gui.ViewModels;
+
+namespace gui.Views;
+
+public partial class MainWindow : Window
+{
+    public MainWindow() => InitializeComponent();
+
+    private MainWindowViewModel? ViewModel => DataContext as MainWindowViewModel;
+
+    private async void OpenClicked(object? sender, RoutedEventArgs e)
+    {
+        IReadOnlyList<IStorageFile> files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Open Neobem file",
+            AllowMultiple = false,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("Neobem files") { Patterns = new[] { "*.nbem" } },
+                FilePickerFileTypes.All,
+            },
+        });
+
+        string? path = files.FirstOrDefault()?.TryGetLocalPath();
+        if (path is not null) ViewModel?.LoadFile(path);
+    }
+
+    private void ReloadClicked(object? sender, RoutedEventArgs e) => ViewModel?.Reload();
+
+    private void SymbolTreeSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (SymbolTree.SelectedItem is not SymbolNode node || ViewModel is null) return;
+        ViewModel.SelectedSymbol = node;
+        HighlightSpan(node.StartIndex, node.StopIndex + 1);
+    }
+
+    private void DiagnosticDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if ((sender as ListBox)?.SelectedItem is not Diagnostic diagnostic || ViewModel is null) return;
+        int offset = OffsetOfLine(ViewModel.SourceText, diagnostic.Line) + diagnostic.Column;
+        HighlightSpan(offset, offset);
+    }
+
+    private void HighlightSpan(int start, int end)
+    {
+        string text = SourceBox.Text ?? "";
+        start = Math.Clamp(start, 0, text.Length);
+        end = Math.Clamp(end, start, text.Length);
+
+        // Setting the caret scrolls it into view; the selection is applied
+        // after so the span stays highlighted.
+        SourceBox.CaretIndex = start;
+        SourceBox.SelectionStart = start;
+        SourceBox.SelectionEnd = end;
+    }
+
+    // Returns the 0-based char offset of the start of a 1-based line number.
+    private static int OffsetOfLine(string text, int line)
+    {
+        int offset = 0;
+        for (int current = 1; current < line; current++)
+        {
+            int next = text.IndexOf('\n', offset);
+            if (next < 0) return offset;
+            offset = next + 1;
+        }
+        return offset;
+    }
+}

--- a/gui/Views/MainWindow.axaml.cs
+++ b/gui/Views/MainWindow.axaml.cs
@@ -12,7 +12,17 @@ namespace gui.Views;
 
 public partial class MainWindow : Window
 {
-    public MainWindow() => InitializeComponent();
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        // Hover and the "at caret" pane follow the caret, since a plain TextBox
+        // gives us no way to hit-test a character under the mouse.
+        SourceBox.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == TextBox.CaretIndexProperty) ViewModel?.UpdateCaret(SourceBox.CaretIndex);
+        };
+    }
 
     private MainWindowViewModel? ViewModel => DataContext as MainWindowViewModel;
 
@@ -47,6 +57,55 @@ public partial class MainWindow : Window
         if ((sender as ListBox)?.SelectedItem is not Diagnostic diagnostic || ViewModel is null) return;
         int offset = OffsetOfLine(ViewModel.SourceText, diagnostic.Line) + diagnostic.Column;
         HighlightSpan(offset, offset);
+    }
+
+    // ---- Language features -------------------------------------------------
+
+    private void WindowKeyDown(object? sender, KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.F12 when e.KeyModifiers.HasFlag(KeyModifiers.Shift):
+                FindReferences();
+                break;
+            case Key.F12:
+                GoToDefinition();
+                break;
+            case Key.Space when e.KeyModifiers.HasFlag(KeyModifiers.Control):
+                ShowCompletions();
+                break;
+            case Key.Escape:
+                ViewModel?.ClearResults();
+                break;
+            default:
+                return;
+        }
+
+        e.Handled = true;
+    }
+
+    private void DefinitionClicked(object? sender, RoutedEventArgs e) => GoToDefinition();
+
+    private void ReferencesClicked(object? sender, RoutedEventArgs e) => FindReferences();
+
+    private void CompletionsClicked(object? sender, RoutedEventArgs e) => ShowCompletions();
+
+    private void CloseResultsClicked(object? sender, RoutedEventArgs e) => ViewModel?.ClearResults();
+
+    private void GoToDefinition()
+    {
+        SourceSpan? span = ViewModel?.GoToDefinition(SourceBox.CaretIndex);
+        if (span is not null) HighlightSpan(span.Start, span.End);
+    }
+
+    private void FindReferences() => ViewModel?.FindReferences(SourceBox.CaretIndex);
+
+    private void ShowCompletions() => ViewModel?.ShowCompletions(SourceBox.CaretIndex);
+
+    private void ResultSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if ((sender as ListBox)?.SelectedItem is not LocationResult result) return;
+        HighlightSpan(result.Span.Start, result.Span.End);
     }
 
     private void HighlightSpan(int start, int end)

--- a/gui/gui.csproj
+++ b/gui/gui.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>nbem-gui</AssemblyName>
+    <Nullable>enable</Nullable>
+    <LangVersion>default</LangVersion>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <RollForward>latestMajor</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <!-- Transitive Avalonia dependency; pinned to pull in the fix for GHSA-xrw6-gwf8-vvr9 -->
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../src/src.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/idf-plus.sln
+++ b/idf-plus.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "test", "test\test.csproj", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "src", "src\src.csproj", "{E0570992-E702-43B8-9ECE-ED171C9191D0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "gui", "gui\gui.csproj", "{B757E506-2A31-4B0A-8514-C5D1D7D1C793}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,26 @@ Global
 		{E0570992-E702-43B8-9ECE-ED171C9191D0}.Release|x64.Build.0 = Release|Any CPU
 		{E0570992-E702-43B8-9ECE-ED171C9191D0}.Release|x86.ActiveCfg = Release|Any CPU
 		{E0570992-E702-43B8-9ECE-ED171C9191D0}.Release|x86.Build.0 = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|ARM.Build.0 = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|x64.Build.0 = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Debug|x86.Build.0 = Debug|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|ARM.ActiveCfg = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|ARM.Build.0 = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|ARM64.Build.0 = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|x64.ActiveCfg = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|x64.Build.0 = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|x86.ActiveCfg = Release|Any CPU
+		{B757E506-2A31-4B0A-8514-C5D1D7D1C793}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -7,3 +7,6 @@ using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(false)]
 [assembly: InternalsVisibleTo("test")]
+// The GUI drives the same language-service logic as the LSP server, but
+// in-process instead of over stdio.
+[assembly: InternalsVisibleTo("nbem-gui")]

--- a/src/Lsp.cs
+++ b/src/Lsp.cs
@@ -38,6 +38,11 @@ internal sealed class LanguageServer
     private int _exitCode;
 
     private static readonly Dictionary<string, BuiltInSymbol> BuiltInSymbols = CreateBuiltInSymbols();
+
+    // The stdio server logs every message to a temp file. In-process consumers
+    // (the GUI) run the same code on every keystroke and turn this off.
+    internal static bool LoggingEnabled { get; set; } = true;
+
     private static readonly object LogLock = new();
     private static readonly string LogFilePath = DetermineLogFilePath();
 
@@ -551,6 +556,11 @@ internal sealed class LanguageServer
 
     private static void Log(string message)
     {
+        if (!LoggingEnabled)
+        {
+            return;
+        }
+
         try
         {
             string logEntry = $"{DateTime.UtcNow:O} {message}{Environment.NewLine}";
@@ -567,6 +577,11 @@ internal sealed class LanguageServer
 
     private static void Log(string message, string filename)
     {
+        if (!LoggingEnabled)
+        {
+            return;
+        }
+
         try
         {
             string logEntry = $"{DateTime.UtcNow:O} {message}{Environment.NewLine}";
@@ -668,6 +683,13 @@ internal sealed class LanguageServer
             _ => FileType.Idf
         };
     }
+
+    // Hover content for a built-in identifier, for callers that want the text
+    // without speaking JSON-RPC. Null when the identifier is not a built-in.
+    public static string? TryGetBuiltInHoverMarkdown(string? identifier) =>
+        !string.IsNullOrEmpty(identifier) && BuiltInSymbols.TryGetValue(identifier, out BuiltInSymbol? symbol)
+            ? BuildHoverMarkdown(symbol)
+            : null;
 
     private static string BuildHoverMarkdown(BuiltInSymbol symbol)
     {


### PR DESCRIPTION
New gui project (nbem-gui) that parses .nbem files with the existing ANTLR parser via a ProjectReference to src, and shows:

- A nested structure tree (imports, variables, functions, objects, let bindings, print/log statements) built by StructureWalker, which is GUI-agnostic so it can later back an LSP documentSymbol.
- A read-only source pane; selecting a tree node highlights and scrolls to its span.
- Parse diagnostics with double-click-to-jump, a detail pane, a symbol filter box, and auto-reload via FileSystemWatcher.

Also supports a headless 'nbem-gui --dump file.nbem' mode that prints the structure tree to stdout for scripting and smoke tests.